### PR TITLE
Feat: fetch priority from the environment if present else set it to a default value

### DIFF
--- a/kong/plugins/config-by-env/handler.lua
+++ b/kong/plugins/config-by-env/handler.lua
@@ -1,4 +1,4 @@
-local AppConfigHandler = {PRIORITY = 10000}
+local AppConfigHandler = {PRIORITY = tonumber(os.getenv("PRIORITY_CONFIG_BY_ENV")) or 10000}
 local singletons = require "kong.singletons"
 local config_loader = require "kong.plugins.config-by-env.config"
 
@@ -7,6 +7,8 @@ local pl_utils = require "pl.utils"
 local pl_stringx = require "pl.stringx"
 
 local inspect = require "inspect"
+
+kong.log.info("Plugin priority set to " .. AppConfigHandler.PRIORITY .. (os.getenv("PRIORITY_CONFIG_BY_ENV") and " from env" or " by default"))
 
 function AppConfigHandler:access(conf)
     local config, err = config_loader.get_config();

--- a/kong/plugins/config-by-env/handler.lua
+++ b/kong/plugins/config-by-env/handler.lua
@@ -1,4 +1,3 @@
-local AppConfigHandler = {PRIORITY = tonumber(os.getenv("PRIORITY_CONFIG_BY_ENV")) or 10000}
 local singletons = require "kong.singletons"
 local config_loader = require "kong.plugins.config-by-env.config"
 
@@ -8,6 +7,7 @@ local pl_stringx = require "pl.stringx"
 
 local inspect = require "inspect"
 
+local AppConfigHandler = {PRIORITY = tonumber(os.getenv("PRIORITY_CONFIG_BY_ENV")) or 10000}
 kong.log.info("Plugin priority set to " .. AppConfigHandler.PRIORITY .. (os.getenv("PRIORITY_CONFIG_BY_ENV") and " from env" or " by default"))
 
 function AppConfigHandler:access(conf)


### PR DESCRIPTION
### Summary
Sets plugin's priority from the environment variable if present else sets it to a default value hardcoded in handler.lua