### PR TITLE
feat: add support for Kong 3.X

### DIFF
--- a/.pongo/pongorc
+++ b/.pongo/pongorc
@@ -1,2 +1,2 @@
 --postgres
---cassandra
+--no-cassandra

--- a/kong/plugins/config-by-env/config.lua
+++ b/kong/plugins/config-by-env/config.lua
@@ -1,100 +1,39 @@
-local inspect = require("inspect")
 local cjson_safe = require "cjson.safe"
 local utils = require "kong.plugins.config-by-env.utils"
 
-local function load_plugin_from_db(key)
-	local row, err = kong.db.plugins:select_by_cache_key(key)
-	if err then
-		return nil, tostring(err)
-	end
-	return row
+local ngx = ngx
+
+local function process_config(conf)
+    local config, err = cjson_safe.decode(conf.config)
+    local env = os.getenv("KONG_ENV")
+    if err then
+        kong.log.err(err)
+        error("Error in parsing config-by-env as table")
+        return nil
+    end
+
+    local final_config = utils.tableMerge(config["default"], config[env])
+    local success, err = utils.traverseTableAndTransformLeaves(final_config, utils.replaceStringEnvVariables)
+    if not success then
+        error(err)
+    end
+
+    kong.log.inspect("Processed Config:", final_config)
+    return final_config
 end
 
-local function load_plugin_from_cache(name)
-	local cache_key = kong.db.plugins:cache_key(name)
-	local opts = {ttl = 0}
-	local plugin, err = kong.core_cache:get(cache_key, opts, load_plugin_from_db, cache_key)
-	if err then
-		kong.log.err(err)
-		return false, {status = 500, message = "Error in loading from cache"}
-	end
-	return plugin
+local function get_config(conf)
+    local config, err = kong.cache:get("config-by-env-final", {
+        ttl = 0
+    }, process_config, conf)
+
+    if err then
+        return false
+    end
+    return config
 end
-
-local function load_config_from_db()
-	local plugin, err = load_plugin_from_cache("config-by-env")
-	if err then
-		kong.log.err(err)
-		return false, {
-			status = 500,
-			message = "Error in loading config-by-env from cache",
-		}
-	end
-	local config, err1 = cjson_safe.decode(plugin["config"]["config"])
-	if err1 then
-		kong.log.err(err1)
-		error("Error in parsing config-by-env as table")
-		return nil
-	end
-	local env = os.getenv("KONG_ENV")
-	local final_config = utils.tableMerge(config["default"], config[env])
-
-	local success, err = utils.traverseTableAndTransformLeaves(final_config, utils.replaceStringEnvVariables)
-	if not success then
-		error(err)
-	end
-
-	kong.log.notice("Final config loaded from db: ", inspect(final_config))
-	return final_config
-end
-
-local function get_config()
-	local config, err = kong.core_cache:get("config-by-env-final", nil, load_config_from_db)
-	if err then
-		return false, "Error in fetching configuration from config-by-env plugin"
-	end
-	return config
-end
-
-local function get_service_name()
-	local service_name = kong.router.get_service()["name"]
-
-	if os.getenv("KONG_KIC") == "on" then
-		local service_name_og = service_name
-		local splitted_service_name = pl_stringx.split(service_name_og, '.')
-		if #splitted_service_name == 3 then
-			service_name = splitted_service_name[2]
-			kong.log.debug(string.format("derived service name for k8 env from %s is %s", service_name_og, service_name))
-		end
-	end
-
-	return service_name
-end
-
-local function get_service_url(service_name)
-	local config, err = get_config()
-	if err then
-		kong.log.err(err)
-		return false, {status = 500, message = "Error in loading config-by-env"}
-	end
-
-	if config["services"] == nil then
-		return false, {status = 500, message = "Could not find service urls in the config."}
-	end
-
-	local service_url = config["services"][service_name]
-	if service_url == nil then
-		kong.log.err("Could not find service URL for service name: " .. service_name)
-	else
-		kong.log.debug(string.format("service URL fetched for service %s is %s", service_name, service_url))
-	end
-
-	return service_url
-end
-
 
 local _M = {}
 _M.get_config = get_config
-_M.get_service_url = get_service_url
-_M.get_service_name = get_service_name
+
 return _M

--- a/kong/plugins/config-by-env/schema.lua
+++ b/kong/plugins/config-by-env/schema.lua
@@ -13,39 +13,30 @@ local function json_validator(config_string)
 end
 
 local function schema_validator(conf)
-	return json_validator(conf.config)
+    return json_validator(conf.config)
 end
 
-
-
 return {
-	name = "config-by-env",
-	fields = {
-		{
-			consumer = typedefs.no_consumer
-		},
-		{
-			protocols = typedefs.protocols_http
-		},
-		{
-			config = {
-				type = "record",
-				fields = {
-					{
-						config = {
-							type = "string",
-							required = true
-						}
-					},
-					{
-						set_service_url = {
-							type = "boolean",
-							default = false
-						}
-					},
-				},
-                custom_validator = schema_validator
-			},
-		}
-	}
+    name = "config-by-env",
+    fields = {{
+        consumer = typedefs.no_consumer
+    }, {
+        protocols = typedefs.protocols_http
+    }, {
+        config = {
+            type = "record",
+            fields = {{
+                config = {
+                    type = "string",
+                    required = true
+                }
+            }, {
+                set_service_url = {
+                    type = "boolean",
+                    default = false
+                }
+            }},
+            custom_validator = schema_validator
+        }
+    }}
 }

--- a/kong/plugins/config-by-env/utils.lua
+++ b/kong/plugins/config-by-env/utils.lua
@@ -1,64 +1,58 @@
-local inspect = require "inspect"
 local function replaceStringEnvVariables(s)
-	local result =
-		string.gsub(
-		s,
-		"%%[A-Z_]+%%",
-		function(str)
-            local env_variable = string.sub(str, 2, string.len(str) - 1)
-            local result = os.getenv(env_variable)
-			if result == nil then
-				kong.log.err("Environment variable is not set: " .. env_variable)
-				error("Throwing error since environment variable is not set: " .. env_variable)
-			end
-            kong.log.notice("Interpolating env variable: " .. env_variable)
-            kong.log.notice("Value::" .. inspect(result))
-            result = result:gsub("\\([nt])", {n="\n", t="\t"})
-			kong.log.debug("Result of replaceStringEnvVariables is: ", result)
-            return result
-		end
-	)
-	return result
+    local result = string.gsub(s, "%%[A-Z_]+%%", function(str)
+        local env_variable = string.sub(str, 2, string.len(str) - 1)
+        local result = os.getenv(env_variable)
+        if result == nil then
+            kong.log.err("Environment variable is not set: " .. env_variable)
+            error("Throwing error since environment variable is not set: " .. env_variable)
+        end
+        result = result:gsub("\\([nt])", {
+            n = "\n",
+            t = "\t"
+        })
+        return result
+    end)
+    return result
 end
 
 local function traverseTableAndTransformLeaves(e, transform_function)
-	for k, v in pairs(e) do -- for every element in the table
-		if type(v) == "table" then
-			local success, err = traverseTableAndTransformLeaves(e[k], transform_function)
-			if not success then
-				return false, err
-			end
-		else
-			if type(v) == "string" then
-				local success, val = pcall(transform_function, v)
-				if not success then
-					kong.log.err("Error inside traverseTableAndTransformLeaves: ", val)
-					return false, val
-				else
-					e[k] = val
-				end
-			end
-		end
-	end
-	return true
+    for k, v in pairs(e) do -- for every element in the table
+        if type(v) == "table" then
+            local success, err = traverseTableAndTransformLeaves(e[k], transform_function)
+            if not success then
+                return false, err
+            end
+        else
+            if type(v) == "string" then
+                local success, val = pcall(transform_function, v)
+                if not success then
+                    kong.log.err("Error inside traverseTableAndTransformLeaves: ", val)
+                    return false, val
+                else
+                    e[k] = val
+                end
+            end
+        end
+    end
+    return true
 end
 
 local function tableMerge(t1, t2)
     if not t2 then
         return t1
     end
-	for k, v in pairs(t2) do
-		if type(v) == "table" then
-			if type(t1[k] or false) == "table" then
-				tableMerge(t1[k] or {}, t2[k] or {})
-			else
-				t1[k] = v
-			end
-		else
-			t1[k] = v
-		end
-	end
-	return t1
+    for k, v in pairs(t2) do
+        if type(v) == "table" then
+            if type(t1[k] or false) == "table" then
+                tableMerge(t1[k] or {}, t2[k] or {})
+            else
+                t1[k] = v
+            end
+        else
+            t1[k] = v
+        end
+    end
+    return t1
 end
 
 local _M = {}

--- a/spec/config-by-env/cache_invalidation_spec.lua
+++ b/spec/config-by-env/cache_invalidation_spec.lua
@@ -2,33 +2,34 @@ local cjson = require "cjson"
 local helpers = require "spec.helpers"
 local fixtures = require "spec.config-by-env.fixtures"
 
-for _, strategy in helpers.each_strategy() do
+for _, strategy in helpers.each_strategy({"postgres"}) do
     describe("config-by-env plugin [#" .. strategy .. "]", function()
-        local proxy_client;
+        local proxy_client
         local bp
         local db
-        local mock_host = helpers.mock_upstream_host;
+        local mock_host = helpers.mock_upstream_host
         local mock_port = 10001
         local admin_client
         local app_config_plugin
         setup(function()
-            bp, db = helpers.get_db_utils(strategy, {"routes", "services", "plugins"}, {"config-by-env"});
+            bp, db = helpers.get_db_utils(strategy, {"routes", "services", "plugins"}, {"config-by-env"})
 
             assert(bp.routes:insert({
                 hosts = {"test.com"},
                 protocols = {"http"},
-                service = bp.services:insert(
-                    {
-                        protocol = "http",
-                        host = mock_host, -- Just a dummy value. Not honoured
-                        port = mock_port, -- Just a dummy value. Not honoured
-                        name = "test"
-                    })
+                service = bp.services:insert({
+                    protocol = "http",
+                    host = mock_host, -- Just a dummy value. Not honoured
+                    port = mock_port, -- Just a dummy value. Not honoured
+                    name = "test"
+                })
             }))
 
             local input = {
                 default = {
-                    services = {test = mock_host .. ":" .. mock_port},
+                    services = {
+                        test = mock_host .. ":" .. mock_port
+                    },
                     upstream_port = mock_port
                 },
                 staging = {},
@@ -61,12 +62,13 @@ for _, strategy in helpers.each_strategy() do
 
         describe("Cache is invalidated on updating config-by-env", function()
             it("Initially request should be proxied to old port", function()
-                local res = assert(proxy_client:send(
-                                       {
-                        method = "GET",
-                        path = "/test",
-                        headers = {Host = "test.com"}
-                    }))
+                local res = assert(proxy_client:send({
+                    method = "GET",
+                    path = "/test",
+                    headers = {
+                        Host = "test.com"
+                    }
+                }))
 
                 assert(res.status == 200)
                 local body_data = assert(res:read_body())
@@ -77,7 +79,9 @@ for _, strategy in helpers.each_strategy() do
 
                 local input1 = {
                     default = {
-                        services = {test = mock_host .. ":" .. 10002}, -- this is a new service url
+                        services = {
+                            test = mock_host .. ":" .. 10002
+                        }, -- this is a new service url
                         upstream_port = mock_port
                     },
                     staging = {},
@@ -86,22 +90,28 @@ for _, strategy in helpers.each_strategy() do
 
                 local url = "/plugins/" .. app_config_plugin["id"]
 
-                local admin_res = assert(
-                                      admin_client:patch(url, {
-                        headers = {["Content-Type"] = "application/json"},
-                        body = {
-                            name = "config-by-env",
-                            config = {config = cjson.encode(input1)}
+                local admin_res = assert(admin_client:patch(url, {
+                    headers = {
+                        ["Content-Type"] = "application/json"
+                    },
+                    body = {
+                        name = "config-by-env",
+                        config = {
+                            config = cjson.encode(input1)
                         }
-                    }))
+                    }
+                }))
                 assert.res_status(200, admin_res)
 
-                local res1 = assert(proxy_client:send(
-                                        {
-                        method = "GET",
-                        path = "/test",
-                        headers = {Host = "test.com"}
-                    }))
+                helpers.wait_for_invalidation("config-by-env-final")
+
+                local res1 = assert(proxy_client:send({
+                    method = "GET",
+                    path = "/test",
+                    headers = {
+                        Host = "test.com"
+                    }
+                }))
 
                 assert(res1.status == 200)
                 local body_data1 = assert(res1:read_body())


### PR DESCRIPTION
# Summary

Make Plugin work for Kong 3.X
Fixes #7, Fixes #16 

# Full Changelog

- replace kong.singletons.* with kong.* Refer https://github.com/Kong/kong/pull/8874
- refactor code
- update test code to provide plugin config as input. Also wait for invalidation of cache as implementation is different in Kong 3.x
- remove cassandra from testing scope. It is set to be deprecated from Kong.
- remove redundant call to db to get config, with conf parameter in plugin phases. Fixes #7 
- replace kong.core_cache with kong.cache as using core_cache is not recommended
- default port is now 80 and not config.upstream_port (if port not found in service url)
