### PR TITLE
fix: release workflow commit push to master

### DIFF
--- a/.ci/scripts/bump-rockspec.sh
+++ b/.ci/scripts/bump-rockspec.sh
@@ -16,17 +16,7 @@ new_file_name="$prefix$new_version$suffix"
 git config user.name github-actions
 git config user.email github-actions@github.com
 
-ACCESS_TOKEN=$2
-REPOSITORY=$3
-BRANCH=${4:-master}
-
-git remote set-url origin https://x-access-token:$ACCESS_TOKEN@github.com/$REPOSITORY
-
-# Fetch all branches and checkout the target branch
-git fetch origin
-git checkout $BRANCH
-
 git mv $file_name $new_file_name
 git add .
 git commit -m "chore: bump version from $version to $new_version"
-git push origin $BRANCH
+git push origin HEAD:master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Publish Release
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   upload_to_luarocks:
@@ -15,9 +15,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ secrets.COMMIT_ACCESS_TOKEN }}
 
     - name: Bump Rockspec version
-      run: .ci/scripts/bump-rockspec.sh ${{ github.event.release.tag_name }} ${{ secrets.COMMIT_ACCESS_TOKEN }} ${{ github.repository }} ${{ github.event.release.target_commitish }}
+      run: .ci/scripts/bump-rockspec.sh ${{ github.event.release.tag_name }}
 
     - name: Install dependencies
       run: .ci/scripts/install-deps.sh


### PR DESCRIPTION
### Summary

Fix release workflow failure when publishing releases. The workflow was failing because it attempted to checkout a branch from a detached HEAD state (when GitHub Actions checks out a release tag).
